### PR TITLE
Add Alacritty theme to Extras folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ this theme has been ported to a few different apps, and are included in the `ext
 * `miasma.Xresources` - colors for [xclients](https://wiki.archlinux.org/title/x_resources) (e.g. unix terminal emulators)
 * `miasma.itermcolors` - colors for [iterm2](https://iterm2.com)
 * `miasma.zsh` - colors for [zsh](https://zsh.org)
+* `miasma.yml` - colors for [alacritty](https://github.com/alacritty/alacritty)
 
 more on the way, and pr's for others are welcomed!
 

--- a/extras/miasma.yml
+++ b/extras/miasma.yml
@@ -1,0 +1,31 @@
+# Colors (Miasma)
+colors:
+  # Default colors
+  primary:
+    background: "#222222"
+    foreground: "#c2c2b0"
+
+  # Normal colors
+  normal:
+    black: "#222222"
+    red: "#685742"
+    green: "#5f875f"
+    yellow: "#b36d43"
+    blue: "#78824b"
+    magenta: "#bb7744"
+    cyan: "#c9a554"
+    white: "#d7c483"
+
+  # Bright colors
+  bright:
+    black: "#666666"
+    red: "#685742"
+    green: "#5f875f"
+    yellow: "#b36d43"
+    blue: "#78824b"
+    magenta: "#bb7744"
+    cyan: "#c9a554"
+    white: "#d7c483"
+
+  indexed_colors:
+    - { index: 16, color: "0x222222" }


### PR DESCRIPTION
Add alacritty theme to extras folder. 
To use this you only need to import the file in your alacritty config:
```
import:
  - ~/.config/alacritty/miasma.yml 
```
preview: 
![image](https://github.com/xero/miasma.nvim/assets/6445354/5efa4dc1-5a1a-4664-952b-afa10b497a50)
