### PR TITLE
Fix #3

### DIFF
--- a/colors/miasma.vim
+++ b/colors/miasma.vim
@@ -132,6 +132,7 @@ hi! link CtrlPLinePre Comment
 hi! link CtrlPMatch String
 hi! link CursorLineFold FoldColumn
 hi! link CursorLineSign SignColumn
+hi! link CurSearch Search
 hi! link Debug Special
 hi! link Define PreProc
 hi! link DiagnosticErrorFloating DiagnosticError
@@ -255,6 +256,7 @@ hi! link Substitute Search
 hi! link Tag Special
 hi! link TelescopeMatching Special
 hi! link TelescopePreviewBorder TelescopeBorder
+hi! link TelescopePreviewLine TelescopeSelection
 hi! link TelescopePreviewTitle TelescopeTitle
 hi! link TelescopePromptCounter TelescopeBorder
 hi! link TelescopePromptPrefix TelescopeTitle

--- a/colors/miasma.vim
+++ b/colors/miasma.vim
@@ -380,7 +380,6 @@ hi TelescopePreviewDirectory guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NON
 hi TelescopePreviewExecute guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NONE
 hi TelescopePreviewGroup guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NONE
 hi TelescopePreviewHyphen guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NONE
-hi TelescopePreviewLine guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NONE
 hi TelescopePreviewLink guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NONE
 hi TelescopePreviewMatch guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NONE
 hi TelescopePreviewMessageFillchar guifg=NONE guibg=NONE guisp=NONE blend=NONE gui=NONE


### PR DESCRIPTION
Fixes https://github.com/xero/miasma.nvim/issues/3
Now the current searched line is highlighted when using Telescope search

<img width="1534" alt="Screenshot 2023-10-18 at 17 45 20" src="https://github.com/xero/miasma.nvim/assets/7441453/4485e639-b9bd-4d33-aa7e-c27e2f46ef82">
